### PR TITLE
feat: add Unitree G1 support for iDP3 (26-DOF config + data converter)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,201 @@
+# iDP3 Model Architecture — G1 Bucket-Emptying Task
+
+This documents the model trained as `g1_dex-3d-idp3-empty_bucket_v2_seed0`, and the
+augmentation/RGB changes added afterwards for the next training run.
+
+## Overview
+
+- **Robot**: Unitree G1 humanoid + Inspire/BrainCo dexterous hands.
+- **Task** (`g1_task`, `diffusion_policy_3d/config/task/g1_dex-3d.yaml`): pick up a bucket
+  with one hand while the other hand helps empty it into a box.
+- **Algorithm**: iDP3 (point-cloud-conditioned diffusion policy), trained via
+  `diffusion_policy_3d/workspace/idp3_workspace.py`.
+- **Action space**: 26 raw joint angles — `[0:7] left_arm`, `[7:14] right_arm`,
+  `[14:20] left_hand`, `[20:26] right_hand`. No end-effector/Cartesian targets.
+
+## Observation / Action Spaces
+
+From `shape_meta` (`diffusion_policy_3d/config/task/g1_dex-3d.yaml`):
+
+| Key | Shape | Type | Notes |
+|---|---|---|---|
+| `point_cloud` | `[4096, 6]` | point_cloud | XYZ + RGB (RGB normalized to `[0,1]`) |
+| `agent_pos` | `[26]` | low_dim | proprioception (joint angles) |
+| `action` | `[26]` | — | joint-angle targets |
+
+**Temporal config** (`diffusion_policy_3d/config/idp3.yaml`):
+- `n_obs_steps = 2`, `horizon = 16`, `n_action_steps = 15` (predict 16, execute 15,
+  re-plan with 2-step observation history).
+
+## Point Cloud Encoder
+
+`iDP3Encoder` (`diffusion_policy_3d/model/vision_3d/pointnet_extractor.py`) combines:
+
+1. **Multi-Stage PointNet** (`diffusion_policy_3d/model/vision_3d/multi_stage_pointnet.py`)
+   - `in_channels`: 3 (XYZ-only, original run) → **6 (XYZ+RGB) for the new run**, see
+     [Point Cloud Color (RGB)](#point-cloud-color-rgb) below.
+   - `h_dim = 128`, `out_channels = 128`, `num_layers = 4`.
+   - 4-stage local→global feature extraction with per-stage max-pooling, concatenated
+     (4×128=512) and projected to `out_channels=128`, then global max-pool → `[B,128]`.
+   - `use_layernorm: true`, `final_norm: layernorm`, `normal_channel: false`.
+2. **Proprioception MLP**: `agent_pos` (26-dim) → `64 → 64` MLP → `[B,64]`.
+3. **Final encoder output**: concat → `[B,192]` (192 = 128 point-cloud feats + 64 state feats).
+
+**Point cloud preprocessing**: `point_downsample: true`, points are uniform-randomly
+re-sampled/shuffled to `num_points=4096` on every `__getitem__`
+(`diffusion_policy_3d/model/vision_3d/point_process.py:uniform_sampling_numpy`). Since the
+zarr already stores exactly 4096 points/frame, this is effectively a random re-shuffle
+(harmless — PointNet is permutation-invariant via max-pooling).
+
+## Diffusion Model
+
+`ConditionalUnet1D` (`diffusion_policy_3d/model/diffusion/conditional_unet1d.py`), driven
+by `DiffusionPointcloudPolicy` (`diffusion_policy_3d/policy/diffusion_pointcloud_policy.py`):
+
+- `down_dims = [256, 512, 1024]`, `kernel_size = 5`, `n_groups = 8` (GroupNorm),
+  `diffusion_step_embed_dim = 128`.
+- FiLM conditioning: `obs_as_global_cond: true`, `use_down_condition/use_mid_condition/use_up_condition: true`.
+- Conditioning vector = diffusion-step embedding (128) + observation encoding (192) = 320-dim.
+
+**Noise scheduler**: DDIM (`diffusers.schedulers.scheduling_ddim.DDIMScheduler`)
+- `num_train_timesteps = 50`, `num_inference_steps = 10` (5x faster sampling at deploy time).
+- `beta_schedule = squaredcos_cap_v2`, `beta_start = 1e-4`, `beta_end = 0.02`.
+- `prediction_type = sample` (model predicts the clean trajectory directly).
+- `clip_sample = true`, `set_alpha_to_one = true`.
+
+## EMA
+
+`diffusion_policy_3d/model/diffusion/ema_model.py`, enabled (`use_ema: true`):
+- `update_after_step = 0`, `inv_gamma = 1.0`, `power = 0.75`, `min_value = 0.0`, `max_value = 0.9999`.
+- Decay ramps up from 0 toward 0.9999 as training progresses (≈0.999 by ~10k steps).
+
+## Optimizer & LR Schedule
+
+- **Optimizer**: AdamW, `lr = 1e-4`, `betas = [0.95, 0.999]`, `eps = 1e-8`, `weight_decay = 1e-6`.
+- **LR schedule**: cosine, `lr_warmup_steps = 500`.
+
+## Training Hyperparameters
+
+- `num_epochs = 301`, `batch_size = 24` (train & val), `gradient_accumulate_every = 1`.
+- `val_every = 100`, `checkpoint_every = 100`.
+- Checkpointing: `save_last_ckpt: true`, `topk.k = 0` → only `latest.ckpt` is kept (no
+  best-epoch snapshot). `topk.monitor_key = test_mean_score` (mode max), but with `k=0`
+  this never actually saves a top-k checkpoint.
+
+## Data Augmentation & Preprocessing
+
+### What existed in the `empty_bucket_v2_seed0` run (audit result)
+
+- **Existed**: per-`__getitem__` point resampling/shuffling to 4096 points (incidental,
+  not real augmentation since the zarr already has exactly 4096 pts/frame); action
+  min-max normalization to `[-1,1]` (`gr1_dex_dataset_3d.py:get_normalizer`,
+  `mode='limits'`); `point_cloud`/`agent_pos` use **identity** normalization (no scaling);
+  RGB channels discarded (`use_pc_color: false`).
+- **Absent**: any Gaussian noise/jitter, random rotation/translation/scaling, point
+  dropout, image augmentation (n/a — no RGB images fed to the policy), temporal/sequence
+  augmentation.
+
+So the `empty_bucket_v2_seed0` model was trained on essentially raw, unaugmented point
+clouds — it has only ever seen the exact geometry of your demonstrations.
+
+### New: point cloud jitter + dropout (`diffusion_policy_3d/dataset/gr1_dex_dataset_3d.py`)
+
+Added to `GR1DexDataset3D`, applied in `_sample_to_data` after the 4096-point resampling,
+controlled by new `task.dataset` config keys (set in `g1_dex-3d.yaml`):
+
+```yaml
+use_pc_augmentation: true
+pc_jitter_std: 0.005   # meters, gaussian jitter on point cloud XYZ
+pc_dropout_ratio: 0.05 # fraction of points replaced with duplicates each frame
+```
+
+- **Jitter**: adds `N(0, pc_jitter_std)` noise to XYZ only (channels `:3`); RGB channels
+  are untouched. Simulates depth-sensor noise — doesn't change the scene's overall
+  geometry, so the (observation, action) pairing stays valid.
+- **Dropout**: for each frame, `round(4096 * pc_dropout_ratio)` random points are
+  overwritten (all 6 channels) with copies of other random points in the same frame —
+  simulates missing/occluded depth returns while preserving the point count.
+- Applied independently per frame in the `horizon`-length sequence.
+- `get_validation_dataset()` disables augmentation on its copy (relevant only if
+  `val_ratio > 0` is used in the future — currently `val_ratio: 0.0`).
+- Tune/disable via Hydra overrides, e.g.:
+  `task.dataset.pc_jitter_std=0.01`, `task.dataset.use_pc_augmentation=false`.
+
+**Known minor side-effect**: the in-loop "validation" pass in `idp3_workspace.py`
+(lines 238-258) re-iterates `train_dataloader`, so `train_action_mse_error`/
+`test_mean_score` will now also see jittered/dropout point clouds, slightly inflating
+that number. This metric was already training-set MSE (not a held-out signal, since
+`val_ratio=0.0`), so this is cosmetic.
+
+## Point Cloud Color (RGB)
+
+The conversion script (`scripts/convert_unitree_to_zarr.py`) has always written
+6-channel point clouds — `point_cloud` shape `(N_frames, 4096, 6)`, channels 3-5 = RGB
+normalized to `[0,1]` (`color = rgb / 255.0`). The `empty_bucket_v2_seed0` model never
+used this — `policy.use_pc_color: false` stripped the point cloud to XYZ only.
+
+**Now enabled by default for G1** (`scripts/train_policy.sh` passes):
+```
+policy.use_pc_color=true
+policy.pointcloud_encoder_cfg.in_channels=6
+```
+
+Code changes that made this work:
+- `MultiStagePointNetEncoder` (`model/vision_3d/multi_stage_pointnet.py`) used to
+  hardcode `Conv1d(3, h_dim, ...)` and ignore the `in_channels` config entirely. It now
+  takes `in_channels` (default `3`, backward compatible) and builds
+  `Conv1d(in_channels, h_dim, ...)` accordingly.
+- `iDP3Encoder` (`model/vision_3d/pointnet_extractor.py`) now passes
+  `in_channels=pointcloud_encoder_cfg.in_channels` through to the PointNet encoder.
+- `DiffusionPointcloudPolicy` (`policy/diffusion_pointcloud_policy.py`) previously did
+  `point_cloud[..., 3:] /= 255.0` when `use_pc_color=True`. Since this dataset's RGB is
+  *already* `[0,1]`, that extra division has been removed (it would have shrunk color
+  values to `~[0, 0.004]`, effectively zeroing the signal).
+
+**Important**: changing `in_channels` from 3→6 changes the shape of the encoder's first
+conv layer, so **the existing `latest.ckpt` cannot be resumed/fine-tuned** — this must be
+trained from scratch with a new run directory, e.g.:
+```
+bash scripts/train_policy.sh idp3 g1_dex-3d empty_bucket_v2_rgb_aug
+```
+(a new `addition_info` value gives a fresh `exp_name`/`run_dir`, avoiding a shape
+mismatch when `idp3_workspace.py` tries to resume `g1_dex-3d-idp3-empty_bucket_v2_seed0`).
+
+## Next Steps: Spatial Generalization (R2RGen)
+
+If local jitter/dropout + RGB color isn't enough to fix the "approaches the bucket then
+stalls" behavior, the next step suggested by the user is **R2RGen** (arXiv:2510.08547,
+"real-to-real" 3D data generation): a simulator/rendering-free method that repositions
+objects/robot within real point clouds (via a group-wise backtracking strategy +
+camera-aware post-processing) to generate spatially-diverse demonstrations.
+
+**Caveat for this setup**: R2RGen retargets the *action trajectory* to match the
+repositioned scene. This G1 policy's actions are 26 raw **joint angles**, not
+end-effector poses — so repositioning the bucket and correspondingly retargeting the
+joint-angle trajectory would require an **IK solver** for the G1 arms/hands. That's a
+substantially bigger project than the augmentation added here, and should be scoped
+separately if jitter/dropout/RGB don't resolve the stalling behavior.
+
+Other things worth checking first if stalling persists:
+- Whether demonstrations have enough coverage of the final grasp/contact phase (vs. mostly
+  "approach" trajectories) — diffusion policies trained mostly on approach motions can
+  regress toward "no movement" near contact.
+- Whether the gripper/hand occludes the bucket in the point cloud right before grasp in a
+  way training data doesn't represent.
+
+## File Reference Index
+
+| Component | File |
+|---|---|
+| Task config | `diffusion_policy_3d/config/task/g1_dex-3d.yaml` |
+| Base policy/training config | `diffusion_policy_3d/config/idp3.yaml` |
+| Dataset | `diffusion_policy_3d/dataset/gr1_dex_dataset_3d.py` |
+| Point cloud sampling utils | `diffusion_policy_3d/model/vision_3d/point_process.py` |
+| Point cloud encoder | `diffusion_policy_3d/model/vision_3d/pointnet_extractor.py` |
+| Multi-Stage PointNet | `diffusion_policy_3d/model/vision_3d/multi_stage_pointnet.py` |
+| Diffusion policy | `diffusion_policy_3d/policy/diffusion_pointcloud_policy.py` |
+| UNet1D | `diffusion_policy_3d/model/diffusion/conditional_unet1d.py` |
+| EMA | `diffusion_policy_3d/model/diffusion/ema_model.py` |
+| Training loop | `diffusion_policy_3d/workspace/idp3_workspace.py` |
+| Dataset conversion | `scripts/convert_unitree_to_zarr.py` |
+| Training entrypoint | `scripts/train_policy.sh` |

--- a/Improved-3D-Diffusion-Policy/deploy.py
+++ b/Improved-3D-Diffusion-Policy/deploy.py
@@ -3,6 +3,7 @@ import sys
 sys.stdout = open(sys.stdout.fileno(), mode='w', buffering=1)
 sys.stderr = open(sys.stderr.fileno(), mode='w', buffering=1)
 
+import diffusion_policy_3d.compat  # must precede any diffusers import
 import hydra
 import time
 from omegaconf import OmegaConf

--- a/Improved-3D-Diffusion-Policy/diffusion_policy_3d/common/g1_action_util.py
+++ b/Improved-3D-Diffusion-Policy/diffusion_policy_3d/common/g1_action_util.py
@@ -1,0 +1,40 @@
+"""
+Unitree G1 joint layout helpers for iDP3 deployment.
+
+G1 with Inspire / BrainCo hands — 26 DOF, no unused padding:
+  [0:7]   left_arm   (shoulder_pitch, shoulder_roll, shoulder_yaw,
+                       elbow, wrist_roll, wrist_pitch, wrist_yaw)
+  [7:14]  right_arm  (same order)
+  [14:20] left_hand  (6 DOF)
+  [20:26] right_hand (6 DOF)
+
+State == Action: direct 1-to-1 mapping (unlike GR1 which has unused slots).
+"""
+
+import numpy as np
+
+G1_STATE_DIM  = 26
+G1_ACTION_DIM = 26
+
+LEFT_ARM_SLICE   = slice(0,  7)
+RIGHT_ARM_SLICE  = slice(7,  14)
+LEFT_HAND_SLICE  = slice(14, 20)
+RIGHT_HAND_SLICE = slice(20, 26)
+
+# Home pose in radians — update with your robot's measured rest position.
+init_q26 = np.zeros(26, dtype=np.float32)
+
+
+def split_action(action: np.ndarray):
+    """Split a (26,) action into (left_arm, right_arm, left_hand, right_hand)."""
+    return (
+        action[LEFT_ARM_SLICE],
+        action[RIGHT_ARM_SLICE],
+        action[LEFT_HAND_SLICE],
+        action[RIGHT_HAND_SLICE],
+    )
+
+
+def join_action(left_arm, right_arm, left_hand, right_hand) -> np.ndarray:
+    """Reconstruct a (26,) action from its parts."""
+    return np.concatenate([left_arm, right_arm, left_hand, right_hand]).astype(np.float32)

--- a/Improved-3D-Diffusion-Policy/diffusion_policy_3d/compat.py
+++ b/Improved-3D-Diffusion-Policy/diffusion_policy_3d/compat.py
@@ -1,0 +1,8 @@
+try:
+    from huggingface_hub import cached_download  # noqa: F401
+except ImportError:
+    # huggingface_hub>=0.23.0 removed cached_download; patch it back so that
+    # diffusers<=0.20.x (which still references it) can import cleanly.
+    import huggingface_hub
+    from huggingface_hub import hf_hub_download
+    huggingface_hub.cached_download = hf_hub_download

--- a/Improved-3D-Diffusion-Policy/diffusion_policy_3d/config/task/g1_dex-3d.yaml
+++ b/Improved-3D-Diffusion-Policy/diffusion_policy_3d/config/task/g1_dex-3d.yaml
@@ -1,0 +1,27 @@
+name: g1_task
+
+# Unitree G1 + Inspire/BrainCo hands: 26 DOF
+# [0:7]  left_arm  [7:14] right_arm  [14:20] left_hand  [20:26] right_hand
+shape_meta: &shape_meta
+  obs:
+    point_cloud:
+      shape: [4096, 6]
+      type: point_cloud
+    agent_pos:
+      shape: [26]
+      type: low_dim
+  action:
+    shape: [26]
+
+
+dataset:
+  _target_: diffusion_policy_3d.dataset.gr1_dex_dataset_3d.GR1DexDataset3D
+  zarr_path: data/g1_task_zarr
+  horizon: ${horizon}
+  pad_before: ${eval:'${n_obs_steps}-1'}
+  pad_after: ${eval:'${n_action_steps}-1'}
+  seed: 42
+  val_ratio: 0.00
+  max_train_episodes: null
+
+  num_points: ${policy.pointcloud_encoder_cfg.num_points}

--- a/Improved-3D-Diffusion-Policy/diffusion_policy_3d/config/task/g1_dex-3d.yaml
+++ b/Improved-3D-Diffusion-Policy/diffusion_policy_3d/config/task/g1_dex-3d.yaml
@@ -29,3 +29,4 @@ dataset:
   use_pc_augmentation: true
   pc_jitter_std: 0.005   # meters, gaussian jitter on point cloud XYZ
   pc_dropout_ratio: 0.05 # fraction of points replaced with duplicates each frame
+  agent_pos_noise_std: 0.0

--- a/Improved-3D-Diffusion-Policy/diffusion_policy_3d/config/task/g1_dex-3d.yaml
+++ b/Improved-3D-Diffusion-Policy/diffusion_policy_3d/config/task/g1_dex-3d.yaml
@@ -21,7 +21,11 @@ dataset:
   pad_before: ${eval:'${n_obs_steps}-1'}
   pad_after: ${eval:'${n_action_steps}-1'}
   seed: 42
-  val_ratio: 0.00
+  val_ratio: 0.10
   max_train_episodes: null
 
   num_points: ${policy.pointcloud_encoder_cfg.num_points}
+
+  use_pc_augmentation: true
+  pc_jitter_std: 0.005   # meters, gaussian jitter on point cloud XYZ
+  pc_dropout_ratio: 0.05 # fraction of points replaced with duplicates each frame

--- a/Improved-3D-Diffusion-Policy/diffusion_policy_3d/dataset/gr1_dex_dataset_3d.py
+++ b/Improved-3D-Diffusion-Policy/diffusion_policy_3d/dataset/gr1_dex_dataset_3d.py
@@ -12,7 +12,7 @@ from termcolor import cprint
 
 class GR1DexDataset3D(BaseDataset):
     def __init__(self,
-            zarr_path, 
+            zarr_path,
             horizon=1,
             pad_before=0,
             pad_after=0,
@@ -21,12 +21,18 @@ class GR1DexDataset3D(BaseDataset):
             max_train_episodes=None,
             task_name=None,
             num_points=4096,
+            use_pc_augmentation=False,
+            pc_jitter_std=0.005,
+            pc_dropout_ratio=0.0,
             ):
         super().__init__()
         cprint(f'Loading GR1DexDataset from {zarr_path}', 'green')
         self.task_name = task_name
 
         self.num_points = num_points
+        self.use_pc_augmentation = use_pc_augmentation
+        self.pc_jitter_std = pc_jitter_std
+        self.pc_dropout_ratio = pc_dropout_ratio
 
 
         buffer_keys = [
@@ -70,6 +76,7 @@ class GR1DexDataset3D(BaseDataset):
             episode_mask=~self.train_mask
             )
         val_set.train_mask = ~self.train_mask
+        val_set.use_pc_augmentation = False
         return val_set
 
     def get_normalizer(self, mode='limits', **kwargs):
@@ -85,10 +92,35 @@ class GR1DexDataset3D(BaseDataset):
     def __len__(self) -> int:
         return len(self.sampler)
 
+    def _augment_point_cloud(self, point_cloud):
+        """Apply small per-frame jitter/dropout to the (already-sampled) point cloud.
+
+        Jitter only perturbs XYZ (channels :3), leaving color channels untouched.
+        Dropout overwrites a fraction of points (all channels) with copies of other
+        points in the same frame, simulating missing/occluded depth returns while
+        preserving the point count.
+        """
+        T, N, _ = point_cloud.shape
+
+        if self.pc_jitter_std > 0:
+            noise = np.random.normal(0, self.pc_jitter_std, size=(T, N, 3)).astype(np.float32)
+            point_cloud[..., :3] += noise
+
+        if self.pc_dropout_ratio > 0:
+            num_drop = round(N * self.pc_dropout_ratio)
+            for t in range(T):
+                drop_idx = np.random.choice(N, size=num_drop, replace=False)
+                replace_idx = np.random.randint(0, N, size=num_drop)
+                point_cloud[t, drop_idx] = point_cloud[t, replace_idx]
+
+        return point_cloud
+
     def _sample_to_data(self, sample):
         agent_pos = sample['state'][:,].astype(np.float32)
         point_cloud = sample['point_cloud'][:,].astype(np.float32)
         point_cloud = point_process.uniform_sampling_numpy(point_cloud, self.num_points)
+        if self.use_pc_augmentation:
+            point_cloud = self._augment_point_cloud(point_cloud)
         data = {
             'obs': {
                 'agent_pos': agent_pos,

--- a/Improved-3D-Diffusion-Policy/diffusion_policy_3d/dataset/gr1_dex_dataset_3d.py
+++ b/Improved-3D-Diffusion-Policy/diffusion_policy_3d/dataset/gr1_dex_dataset_3d.py
@@ -24,6 +24,7 @@ class GR1DexDataset3D(BaseDataset):
             use_pc_augmentation=False,
             pc_jitter_std=0.005,
             pc_dropout_ratio=0.0,
+            agent_pos_noise_std=0.0,
             ):
         super().__init__()
         cprint(f'Loading GR1DexDataset from {zarr_path}', 'green')
@@ -33,6 +34,7 @@ class GR1DexDataset3D(BaseDataset):
         self.use_pc_augmentation = use_pc_augmentation
         self.pc_jitter_std = pc_jitter_std
         self.pc_dropout_ratio = pc_dropout_ratio
+        self.agent_pos_noise_std = agent_pos_noise_std
 
 
         buffer_keys = [
@@ -77,6 +79,8 @@ class GR1DexDataset3D(BaseDataset):
             )
         val_set.train_mask = ~self.train_mask
         val_set.use_pc_augmentation = False
+        # never inject sensor noise into the held-out/eval copy
+        val_set.agent_pos_noise_std = 0.0
         return val_set
 
     def get_normalizer(self, mode='limits', **kwargs):
@@ -117,6 +121,9 @@ class GR1DexDataset3D(BaseDataset):
 
     def _sample_to_data(self, sample):
         agent_pos = sample['state'][:,].astype(np.float32)
+        if self.agent_pos_noise_std > 0:
+            agent_pos = agent_pos + np.random.normal(
+                0, self.agent_pos_noise_std, size=agent_pos.shape).astype(np.float32)
         point_cloud = sample['point_cloud'][:,].astype(np.float32)
         point_cloud = point_process.uniform_sampling_numpy(point_cloud, self.num_points)
         if self.use_pc_augmentation:

--- a/Improved-3D-Diffusion-Policy/diffusion_policy_3d/model/vision_3d/multi_stage_pointnet.py
+++ b/Improved-3D-Diffusion-Policy/diffusion_policy_3d/model/vision_3d/multi_stage_pointnet.py
@@ -13,7 +13,7 @@ def maxpool(x, dim=-1, keepdim=False):
     return out
 
 class MultiStagePointNetEncoder(nn.Module):
-    def __init__(self, h_dim=128, out_channels=128, num_layers=4, **kwargs):
+    def __init__(self, in_channels=3, h_dim=128, out_channels=128, num_layers=4, **kwargs):
         super().__init__()
 
         self.h_dim = h_dim
@@ -22,7 +22,7 @@ class MultiStagePointNetEncoder(nn.Module):
 
         self.act = nn.LeakyReLU(negative_slope=0.0, inplace=False)
 
-        self.conv_in = nn.Conv1d(3, h_dim, kernel_size=1)
+        self.conv_in = nn.Conv1d(in_channels, h_dim, kernel_size=1)
         self.layers, self.global_layers = nn.ModuleList(), nn.ModuleList()
         for i in range(self.num_layers):
             self.layers.append(nn.Conv1d(h_dim, h_dim, kernel_size=1))

--- a/Improved-3D-Diffusion-Policy/diffusion_policy_3d/model/vision_3d/pointnet_extractor.py
+++ b/Improved-3D-Diffusion-Policy/diffusion_policy_3d/model/vision_3d/pointnet_extractor.py
@@ -117,7 +117,9 @@ class iDP3Encoder(nn.Module):
         
         if pointnet_type == "multi_stage_pointnet":
             from .multi_stage_pointnet import MultiStagePointNetEncoder
-            self.extractor = MultiStagePointNetEncoder(out_channels=pointcloud_encoder_cfg.out_channels)
+            self.extractor = MultiStagePointNetEncoder(
+                in_channels=pointcloud_encoder_cfg.in_channels,
+                out_channels=pointcloud_encoder_cfg.out_channels)
         else:
             raise NotImplementedError(f"pointnet_type: {pointnet_type}")
 

--- a/Improved-3D-Diffusion-Policy/diffusion_policy_3d/policy/diffusion_pointcloud_policy.py
+++ b/Improved-3D-Diffusion-Policy/diffusion_policy_3d/policy/diffusion_pointcloud_policy.py
@@ -134,8 +134,9 @@ class DiffusionPointcloudPolicy(BasePolicy):
         nobs = self.normalizer.normalize(obs_dict)
         if not self.use_pc_color:
             nobs['point_cloud'] = nobs['point_cloud'][..., :3]
-        if self.use_pc_color: # normalize color
-            nobs['point_cloud'][..., 3:] /= 255.0
+        # NOTE: when use_pc_color is True, point_cloud[..., 3:] is already
+        # normalized RGB in [0, 1] (see convert_unitree_to_zarr.py), so no
+        # further scaling is applied here.
         
         value = next(iter(nobs.values()))
         B, To = value.shape[:2]
@@ -239,8 +240,9 @@ class DiffusionPointcloudPolicy(BasePolicy):
         nobs = self.normalizer.normalize(obs_dict)
         if not self.use_pc_color:
             nobs['point_cloud'] = nobs['point_cloud'][..., :3]
-        if self.use_pc_color: # normalize color
-            nobs['point_cloud'][..., 3:] /= 255.0
+        # NOTE: when use_pc_color is True, point_cloud[..., 3:] is already
+        # normalized RGB in [0, 1] (see convert_unitree_to_zarr.py), so no
+        # further scaling is applied here.
         
         
         value = next(iter(nobs.values()))
@@ -320,8 +322,9 @@ class DiffusionPointcloudPolicy(BasePolicy):
 
         if not self.use_pc_color:
             nobs['point_cloud'] = nobs['point_cloud'][..., :3]
-        if self.use_pc_color: # normalize color
-            nobs['point_cloud'][..., 3:] /= 255.0
+        # NOTE: when use_pc_color is True, point_cloud[..., 3:] is already
+        # normalized RGB in [0, 1] (see convert_unitree_to_zarr.py), so no
+        # further scaling is applied here.
 
         batch_size = nactions.shape[0]
         horizon = nactions.shape[1]

--- a/Improved-3D-Diffusion-Policy/train.py
+++ b/Improved-3D-Diffusion-Policy/train.py
@@ -4,6 +4,7 @@ Training:
 python train.py --config-name=train_diffusion_lowdim_workspace
 """
 import os
+import diffusion_policy_3d.compat  # must precede any diffusers import
 from diffusion_policy_3d.workspace.base_workspace import BaseWorkspace
 import pathlib
 from omegaconf import OmegaConf

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ bash scripts/train_policy.sh idp3 g1_dex-3d my_run \
 | Model width | [256,512,1024] | `policy.down_dims` | Reduce to `[128,256,512]` for smaller GPUs |
 | Save checkpoints | False | `checkpoint.save_ckpt` | Set `True` to save every N epochs |
 | Checkpoint interval | 100 | `training.checkpoint_every` | Epochs between checkpoint saves |
+| Agent-pos noise std | 0.0 | `task.dataset.agent_pos_noise_std` | Gaussian noise added to `agent_pos` observations only (never to actions); helps avoid overfitting to exact joint trajectories. Try ~0.01 |
 
 **Deploy.** After you have trained the policy, deploy the policy with the following command. For missing packages such as `communication.py`, see another [our repo](https://github.com/YanjieZe/Humanoid-Teleoperation/tree/main/humanoid_teleoperation/teleop-zenoh)
 

--- a/README.md
+++ b/README.md
@@ -89,24 +89,31 @@ Then you could train the policy and deploy it.
 
 If you collected demonstrations with [xr_teleoperate](https://github.com/unitreerobotics/xr_teleoperate), use the provided conversion script to turn the raw episodes into the zarr format expected by iDP3.
 
-**Step 1 — Get your camera intrinsics.** Run this once on the machine with the RealSense attached:
+**Recommended camera setup (RealSense D435):** 640×480 @ 15 Hz for both colour and depth. This is the D435's best-characterised mode and gives sufficient point density for 4096-point subsampling.
+
+**Step 1 — Get your camera intrinsics.** Run this once with the camera at your target resolution:
 
     python -c "
     import pyrealsense2 as rs
-    p = rs.pipeline(); p.start()
+    cfg = rs.config()
+    cfg.enable_stream(rs.stream.color, 640, 480, rs.format.bgr8, 15)
+    p = rs.pipeline(); p.start(cfg)
     i = p.get_active_profile().get_stream(rs.stream.color) \
           .as_video_stream_profile().get_intrinsics()
-    print(f'fx={i.fx:.2f} fy={i.fy:.2f} cx={i.ppx:.2f} cy={i.ppy:.2f}')
+    print(f'--fx {i.fx:.4f} --fy {i.fy:.4f} --cx {i.ppx:.4f} --cy {i.ppy:.4f}')
     p.stop()"
+
+Intrinsics are per-unit and resolution-specific — always read them from the device rather than using nominal values.
 
 **Step 2 — Convert episodes to zarr:**
 
     python scripts/convert_unitree_to_zarr.py \
         --input_dir  /path/to/your/episodes \
         --output_zarr Improved-3D-Diffusion-Policy/data/g1_task_zarr \
-        --fx <fx> --fy <fy> --cx <cx> --cy <cy>
+        --fx <fx> --fy <fy> --cx <cx> --cy <cy> \
+        --z_near 0.2 --z_far 1.2
 
-The `--input_dir` should contain `episode_0000/`, `episode_0001/`, … subdirectories as written by xr_teleoperate's `EpisodeWriter`.
+The `--input_dir` should contain `episode_0000/`, `episode_0001/`, … subdirectories as written by xr_teleoperate's `EpisodeWriter`. Adjust `--z_far` to match your workspace depth (1.2 m works well for tabletop manipulation).
 
 Optional arguments:
 
@@ -118,6 +125,8 @@ Optional arguments:
 | `--z_near` | `0.1` | Minimum depth (metres) |
 | `--z_far` | `1.5` | Maximum depth (metres) |
 | `--num_points` | `4096` | Points per cloud |
+
+**Deployment on G1 Jetson:** The repo targets Python 3.8, which matches the Jetson environment on the G1. Install PyTorch using NVIDIA's Jetson-specific wheel (JetPack) rather than the standard pip wheel — the standard `torch==2.1.0` build does not support Jetson CUDA.
 
 **Step 3 — Verify the output:**
 

--- a/README.md
+++ b/README.md
@@ -85,10 +85,58 @@ For example,  I put the dataset in `/home/ze/projects/Improved-3D-Diffusion-Poli
 
 Then you could train the policy and deploy it.
 
+### Unitree G1: Converting xr_teleoperate Data
+
+If you collected demonstrations with [xr_teleoperate](https://github.com/unitreerobotics/xr_teleoperate), use the provided conversion script to turn the raw episodes into the zarr format expected by iDP3.
+
+**Step 1 — Get your camera intrinsics.** Run this once on the machine with the RealSense attached:
+
+    python -c "
+    import pyrealsense2 as rs
+    p = rs.pipeline(); p.start()
+    i = p.get_active_profile().get_stream(rs.stream.color) \
+          .as_video_stream_profile().get_intrinsics()
+    print(f'fx={i.fx:.2f} fy={i.fy:.2f} cx={i.ppx:.2f} cy={i.ppy:.2f}')
+    p.stop()"
+
+**Step 2 — Convert episodes to zarr:**
+
+    python scripts/convert_unitree_to_zarr.py \
+        --input_dir  /path/to/your/episodes \
+        --output_zarr Improved-3D-Diffusion-Policy/data/g1_task_zarr \
+        --fx <fx> --fy <fy> --cx <cx> --cy <cy>
+
+The `--input_dir` should contain `episode_0000/`, `episode_0001/`, … subdirectories as written by xr_teleoperate's `EpisodeWriter`.
+
+Optional arguments:
+
+| Argument | Default | Description |
+|---|---|---|
+| `--color_key` | `color_0` | Which colour stream to use for the point cloud |
+| `--depth_key` | `depth_0` | Which depth stream to use |
+| `--depth_scale` | `1000.0` | Divide raw uint16 depth by this to get metres |
+| `--z_near` | `0.1` | Minimum depth (metres) |
+| `--z_far` | `1.5` | Maximum depth (metres) |
+| `--num_points` | `4096` | Points per cloud |
+
+**Step 3 — Verify the output:**
+
+    python -c "
+    import zarr
+    z = zarr.open('Improved-3D-Diffusion-Policy/data/g1_task_zarr', 'r')
+    print('state:      ', z['data/state'].shape)       # (T, 26)
+    print('action:     ', z['data/action'].shape)      # (T, 26)
+    print('point_cloud:', z['data/point_cloud'].shape) # (T, 4096, 6)
+    print('episodes:   ', z['meta/episode_ends'][:])
+    "
+
 **Train.** The script to train policy:
 
-    # 3d policy
+    # 3d policy (GR1)
     bash scripts/train_policy.sh idp3 gr1_dex-3d 0913_example
+
+    # 3d policy (Unitree G1)
+    bash scripts/train_policy.sh idp3 g1_dex-3d g1_experiment
 
     # 2d policy
     bash scripts/train_policy.sh dp_224x224_r3m gr1_dex-image 0913_example

--- a/README.md
+++ b/README.md
@@ -54,11 +54,13 @@ Install conda env and packages for both learning and deployment machines:
 
 
     # install 3d diffusion policy
-    pip install --no-cache-dir wandb ipdb gpustat visdom notebook mediapy torch_geometric natsort scikit-video easydict pandas moviepy imageio imageio-ffmpeg termcolor av open3d dm_control dill==0.3.5.1 hydra-core==1.2.0 einops==0.4.1 diffusers==0.11.1 zarr==2.12.0 numba==0.56.4 pygame==2.1.2 shapely==1.8.4 tensorboard==2.10.1 tensorboardx==2.5.1 absl-py==0.13.0 pyparsing==2.4.7 jupyterlab==3.0.14 scikit-image yapf==0.31.0 opencv-python==4.5.3.56 psutil av matplotlib setuptools==59.5.0
+    pip install --no-cache-dir wandb ipdb gpustat visdom notebook mediapy torch_geometric natsort scikit-video easydict pandas moviepy imageio imageio-ffmpeg termcolor av open3d dm_control dill==0.3.5.1 hydra-core==1.2.0 einops==0.4.1 diffusers==0.20.2 zarr==2.12.0 numba==0.56.4 pygame==2.1.2 shapely==1.8.4 tensorboard==2.10.1 tensorboardx==2.5.1 absl-py==0.13.0 pyparsing==2.4.7 jupyterlab==3.0.14 scikit-image yapf==0.31.0 opencv-python==4.5.3.56 psutil av matplotlib setuptools==59.5.0
 
     cd Improved-3D-Diffusion-Policy
     pip install -e .
     cd ..
+
+> **Note on `huggingface_hub` compatibility:** `diffusers==0.20.2` still references `cached_download`, which was removed in `huggingface_hub>=0.23.0`. A compatibility shim (`diffusion_policy_3d/compat.py`) is included in this repo and applied automatically at the start of `train.py` and `deploy.py` — no manual action required.
 
     # install for diffusion policy if you want to use image-based policy
     pip install timm==0.9.7
@@ -149,6 +151,35 @@ Optional arguments:
 
     # 2d policy
     bash scripts/train_policy.sh dp_224x224_r3m gr1_dex-image 0913_example
+
+### Tuning iDP3 Hyperparameters
+
+All parameters below are [Hydra](https://hydra.cc/) overrides and can be appended directly to the training command:
+
+```bash
+bash scripts/train_policy.sh idp3 g1_dex-3d my_run \
+    training.num_epochs=500 \
+    dataloader.batch_size=32 \
+    val_dataloader.batch_size=32 \
+    n_obs_steps=2 \
+    horizon=16
+```
+
+| Parameter | Default | Override key | Notes |
+|---|---|---|---|
+| Epochs | 301 | `training.num_epochs` | Increase for larger datasets |
+| Batch size | 64 | `dataloader.batch_size` + `val_dataloader.batch_size` | Use 24 for 8 GB GPU, 64 for 24 GB |
+| Learning rate | 1e-4 | `optimizer.lr` | |
+| LR warmup steps | 500 | `training.lr_warmup_steps` | |
+| Obs steps | 2 | `n_obs_steps` | How many past observations fed to policy |
+| Prediction horizon | 16 | `horizon` | Total timesteps predicted per inference |
+| Action steps executed | 15 | `n_action_steps` | Must be ≤ `horizon − 1` |
+| Points per cloud | 4096 | `policy.pointcloud_encoder_cfg.num_points` | Reduce to 1024 to cut memory and speed up training |
+| Diffusion train timesteps | 50 | `policy.noise_scheduler.num_train_timesteps` | |
+| Diffusion inference steps | 10 | `policy.num_inference_steps` | DDIM steps; lower = faster deployment |
+| Model width | [256,512,1024] | `policy.down_dims` | Reduce to `[128,256,512]` for smaller GPUs |
+| Save checkpoints | False | `checkpoint.save_ckpt` | Set `True` to save every N epochs |
+| Checkpoint interval | 100 | `training.checkpoint_every` | Epochs between checkpoint saves |
 
 **Deploy.** After you have trained the policy, deploy the policy with the following command. For missing packages such as `communication.py`, see another [our repo](https://github.com/YanjieZe/Humanoid-Teleoperation/tree/main/humanoid_teleoperation/teleop-zenoh)
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,24 @@ Note that you may not run the deployment code without a robot (different robots 
 
 You can specify `vis_cloud=1` to render the point cloud as in the paper.
 
+### Deployment OOD Analysis
+
+After running `scripts/deploy_policy.sh`, each rollout's joint states, actions, and camera frames are saved to `policies/eval_logs/<timestamp>/` (including `episode_log.npz` and per-frame `NNNNNN_{color,depth}.png`). Use the following scripts to check whether a rollout falls outside the training distribution.
+
+**Joint-state / action check** — PCA + Mahalanobis comparison of the rollout's `agent_pos`/action trajectories against the training zarr dataset:
+
+    conda run -n idp3 python scripts/analyze_ood.py --episode-log policies/eval_logs/<run>/episode_log.npz
+
+Writes `pca_agent_pos.png`, `pca_action.png`, and `summary.txt` (Mahalanobis distances + per-joint-group range checks) to `<episode-log dir>/ood_analysis/` by default. Pass `--zarr-path` if your training data isn't `Improved-3D-Diffusion-Policy/data/g1_empty_bucket_v2`.
+
+**Point-cloud encoder check** — reconstructs point clouds from the saved depth/colour PNGs, embeds them with the checkpoint's trained PointNet encoder, and compares against training point-cloud embeddings:
+
+    conda run -n idp3 python scripts/analyze_ood_pointcloud.py --ckpt latest.ckpt
+
+Scans all rollouts under `--eval-logs-dir` (default `policies/eval_logs`) and writes `pca_pointcloud_embedding.png` + `summary.txt` to `policies/eval_logs/pointcloud_ood_analysis/`.
+
+Both scripts share their PCA/Mahalanobis helpers in `scripts/ood_common.py`.
+
 
 ## BibTeX
 

--- a/convert_g1_dataset.sh
+++ b/convert_g1_dataset.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+python scripts/convert_unitree_to_zarr.py \
+      --input_dir /home/luke/MSMD/repos/unitree/xr_teleoperate/teleop/utils/data/empty_bucket_v2 \
+      --output_zarr Improved-3D-Diffusion-Policy/data/g1_empty_bucket_v2 \
+      --fx 607.7126 --fy 607.5232 --cx 319.4251 --cy 243.5345 \
+      --z_near 0.1 --z_far 1

--- a/scripts/analyze_ood.py
+++ b/scripts/analyze_ood.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+PCA / Mahalanobis out-of-distribution (OOD) check for an iDP3 deployment rollout.
+
+Compares the joint-state (agent_pos) and action distributions observed during a
+real deployment rollout (episode_log.npz, written by deploy_policy.sh) against the
+training distribution stored in the zarr dataset the checkpoint was trained on.
+
+Produces:
+  <output-dir>/pca_agent_pos.png - training state distribution (hexbin) + eval trajectory in PC space
+  <output-dir>/pca_action.png    - same for the policy's executed actions
+  <output-dir>/summary.txt       - Mahalanobis-distance OOD scores + per-joint-group range checks
+
+Usage:
+  python scripts/analyze_ood.py --episode-log policies/eval_logs/20260611_113404/episode_log.npz
+
+Run with the idp3 conda env:
+  conda run -n idp3 python scripts/analyze_ood.py --episode-log <path-to-episode_log.npz>
+"""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import zarr
+
+from ood_common import fit_pca, mahalanobis_report, plot_pca
+
+# Unitree G1 + Inspire/BrainCo hands: 26 DOF, see config/task/g1_dex-3d.yaml
+JOINT_GROUPS = {
+    "left_arm": slice(0, 7),
+    "right_arm": slice(7, 14),
+    "left_hand": slice(14, 20),
+    "right_hand": slice(20, 26),
+}
+
+
+def load_training_data(zarr_path):
+    z = zarr.open(str(zarr_path), 'r')
+    return np.asarray(z['data/state'][:]), np.asarray(z['data/action'][:])
+
+
+def load_eval_data(episode_log_path):
+    d = np.load(str(episode_log_path))
+    agent_pos = d['agent_pos']           # (T, 26)
+    actions = d['actions']                # (T, H, 26)
+    return agent_pos, actions[:, 0, :]    # first predicted = executed action
+
+
+def range_check_report(train_data, eval_data, name):
+    lines = [f"-- {name}: per-joint-group range check (eval vs training [min, max]) --"]
+    train_min = train_data.min(axis=0)
+    train_max = train_data.max(axis=0)
+    for group, sl in JOINT_GROUPS.items():
+        below = (train_min[sl] - eval_data[:, sl]).clip(min=0)
+        above = (eval_data[:, sl] - train_max[sl]).clip(min=0)
+        n_violations = ((below > 0) | (above > 0)).sum()
+        n_total = eval_data[:, sl].size
+        lines.append(
+            f"  {group:10s} dims {sl.start:2d}:{sl.stop:2d}: "
+            f"{n_violations:4d}/{n_total:4d} samples out of train range "
+            f"(max below={below.max():.4f}, max above={above.max():.4f})"
+        )
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="PCA / Mahalanobis OOD check for an iDP3 deployment rollout.")
+    parser.add_argument("--zarr-path", type=Path,
+                         default=Path("Improved-3D-Diffusion-Policy/data/g1_empty_bucket_v2"),
+                         help="Training zarr dataset (must contain data/state and data/action)")
+    parser.add_argument("--episode-log", type=Path, required=True,
+                         help="Path to episode_log.npz written during deployment")
+    parser.add_argument("--output-dir", type=Path, default=None,
+                         help="Where to write plots/summary (default: <episode-log dir>/ood_analysis)")
+    args = parser.parse_args()
+
+    output_dir = args.output_dir or (args.episode_log.parent / "ood_analysis")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"Loading training data from {args.zarr_path} ...")
+    train_state, train_action = load_training_data(args.zarr_path)
+    print(f"  state: {train_state.shape}, action: {train_action.shape}")
+
+    print(f"Loading eval rollout from {args.episode_log} ...")
+    eval_state, eval_action = load_eval_data(args.episode_log)
+    print(f"  agent_pos: {eval_state.shape}, executed action: {eval_action.shape}")
+
+    summary_lines = [
+        "=" * 70, "iDP3 Deployment OOD Check", "=" * 70,
+        f"Training data: {args.zarr_path} ({len(train_state)} samples)",
+        f"Eval rollout:  {args.episode_log} ({len(eval_state)} samples)", "",
+    ]
+
+    for name, train_data, eval_data, fname in [
+        ("agent_pos", train_state, eval_state, "pca_agent_pos.png"),
+        ("action", train_action, eval_action, "pca_action.png"),
+    ]:
+        scaler, pca = fit_pca(train_data)
+        train_scaled = pca.transform(scaler.transform(train_data))
+        eval_scaled = pca.transform(scaler.transform(eval_data))
+        var_explained = pca.explained_variance_ratio_.sum() * 100
+
+        plot_path = output_dir / fname
+        plot_pca(train_scaled, eval_scaled,
+                 f"{name}: PCA (train density vs eval rollout, {var_explained:.1f}% var explained)",
+                 plot_path, eval_cmap_label='eval timestep', connect_line=True)
+        print(f"Saved {plot_path}")
+
+        summary_lines.append(mahalanobis_report(train_data, eval_data, name))
+        summary_lines.append("")
+        summary_lines.append(range_check_report(train_data, eval_data, name))
+        summary_lines.append("")
+
+    summary = "\n".join(summary_lines)
+    print("\n" + summary)
+    (output_dir / "summary.txt").write_text(summary + "\n")
+    print(f"\nSaved summary to {output_dir / 'summary.txt'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/analyze_ood_pointcloud.py
+++ b/scripts/analyze_ood_pointcloud.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+Point-cloud-encoder OOD check for an iDP3 checkpoint.
+
+Reconstructs point clouds from the depth+colour PNGs saved during real deployment
+rollouts (policies/eval_logs/**/NNNNNN_{color,depth}.png), runs them through the
+trained PointNet encoder, and compares the resulting embeddings against embeddings
+of the training point clouds via PCA and Mahalanobis distance.
+
+Produces:
+  <output-dir>/pca_pointcloud_embedding.png
+  <output-dir>/summary.txt
+
+Usage:
+  python scripts/analyze_ood_pointcloud.py
+
+Run with the idp3 conda env:
+  conda run -n idp3 python scripts/analyze_ood_pointcloud.py
+"""
+
+import argparse
+from pathlib import Path
+
+import numpy as np
+import torch
+import zarr
+from PIL import Image
+
+from convert_unitree_to_zarr import depth_to_colored_pointcloud
+from ood_common import fit_pca, mahalanobis_report, mahalanobis_scores, plot_pca
+
+from diffusion_policy_3d.model.vision_3d.multi_stage_pointnet import MultiStagePointNetEncoder
+
+# Camera intrinsics used to build data/g1_empty_bucket_v2 (see convert_g1_dataset.sh)
+DEFAULT_INTRINSICS = dict(fx=607.7126, fy=607.5232, cx=319.4251, cy=243.5345)
+DEFAULT_Z_NEAR = 0.1
+DEFAULT_Z_FAR = 1.0
+DEFAULT_DEPTH_SCALE = 1000.0
+
+
+def build_extractor(ckpt_path, device):
+    ckpt = torch.load(str(ckpt_path), map_location='cpu', weights_only=False)
+    cfg = ckpt['cfg']
+    pc_cfg = cfg.policy.pointcloud_encoder_cfg
+    use_pc_color = cfg.policy.use_pc_color
+    in_channels = pc_cfg.in_channels
+
+    extractor = MultiStagePointNetEncoder(in_channels=in_channels, out_channels=pc_cfg.out_channels)
+    sd_key = 'ema_model' if 'ema_model' in ckpt['state_dicts'] else 'model'
+    sd = ckpt['state_dicts'][sd_key]
+    prefix = 'obs_encoder.extractor.'
+    extractor_sd = {k[len(prefix):]: v for k, v in sd.items() if k.startswith(prefix)}
+    extractor.load_state_dict(extractor_sd)
+    extractor.eval().to(device)
+    return extractor, use_pc_color, in_channels
+
+
+def embed_point_clouds(extractor, point_clouds, device, batch_size=256):
+    embeddings = []
+    with torch.no_grad():
+        for i in range(0, len(point_clouds), batch_size):
+            batch = torch.from_numpy(point_clouds[i:i + batch_size]).float().to(device)
+            embeddings.append(extractor(batch).cpu().numpy())
+    return np.concatenate(embeddings, axis=0)
+
+
+def load_training_point_clouds(zarr_path, n_samples, channels, seed=42):
+    z = zarr.open(str(zarr_path), 'r')
+    arr = z['data/point_cloud']
+    n_total = arr.shape[0]
+    rng = np.random.default_rng(seed)
+    idx = np.sort(rng.choice(n_total, size=min(n_samples, n_total), replace=False))
+    clouds = arr.oindex[idx][..., :channels]
+    return np.asarray(clouds, dtype=np.float32), n_total
+
+
+def find_eval_runs(eval_logs_dir):
+    """Return list of (run_dir, sorted_frame_ids) for dirs with NNNNNN_color.png + episode_log.npz."""
+    run_dirs = sorted({p.parent for p in eval_logs_dir.rglob("*_color.png")})
+    runs = []
+    for run_dir in run_dirs:
+        if not (run_dir / "episode_log.npz").exists():
+            continue
+        frames = sorted(p.stem.rsplit('_', 1)[0] for p in run_dir.glob("*_color.png"))
+        runs.append((run_dir, frames))
+    return runs
+
+
+def reconstruct_point_cloud(run_dir, frame_id, intrinsics, z_near, z_far, depth_scale, num_points, channels):
+    color = np.array(Image.open(run_dir / f"{frame_id}_color.png").convert("RGB"))
+    depth_raw = np.array(Image.open(run_dir / f"{frame_id}_depth.png"))
+    depth_m = depth_raw.astype(np.float32) / depth_scale
+    cloud = depth_to_colored_pointcloud(depth_m, color, **intrinsics, z_near=z_near, z_far=z_far, num_points=num_points)
+    return cloud[:, :channels]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Point-cloud-encoder OOD check using deployment depth/color images.")
+    parser.add_argument("--ckpt", type=Path, default=Path("latest.ckpt"))
+    parser.add_argument("--zarr-path", type=Path, default=Path("Improved-3D-Diffusion-Policy/data/g1_empty_bucket_v2"))
+    parser.add_argument("--eval-logs-dir", type=Path, default=Path("policies/eval_logs"))
+    parser.add_argument("--n-train-samples", type=int, default=2000)
+    parser.add_argument("--output-dir", type=Path, default=Path("policies/eval_logs/pointcloud_ood_analysis"))
+    parser.add_argument("--fx", type=float, default=DEFAULT_INTRINSICS['fx'])
+    parser.add_argument("--fy", type=float, default=DEFAULT_INTRINSICS['fy'])
+    parser.add_argument("--cx", type=float, default=DEFAULT_INTRINSICS['cx'])
+    parser.add_argument("--cy", type=float, default=DEFAULT_INTRINSICS['cy'])
+    parser.add_argument("--z-near", type=float, default=DEFAULT_Z_NEAR)
+    parser.add_argument("--z-far", type=float, default=DEFAULT_Z_FAR)
+    parser.add_argument("--depth-scale", type=float, default=DEFAULT_DEPTH_SCALE)
+    parser.add_argument("--num-points", type=int, default=4096)
+    args = parser.parse_args()
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    print(f"Loading encoder from {args.ckpt} (device={device}) ...")
+    extractor, use_pc_color, in_channels = build_extractor(args.ckpt, device)
+    print(f"  use_pc_color={use_pc_color}, in_channels={in_channels}")
+
+    print(f"Sampling {args.n_train_samples} training point clouds from {args.zarr_path} ...")
+    train_clouds, n_train_total = load_training_point_clouds(args.zarr_path, args.n_train_samples, in_channels)
+    print(f"  train_clouds: {train_clouds.shape} (of {n_train_total} total)")
+
+    runs = find_eval_runs(args.eval_logs_dir)
+    print(f"Found {len(runs)} eval rollouts under {args.eval_logs_dir}")
+
+    intrinsics = dict(fx=args.fx, fy=args.fy, cx=args.cx, cy=args.cy)
+    eval_clouds = []
+    eval_run_idx = []
+    for run_i, (run_dir, frames) in enumerate(runs):
+        print(f"  [{run_i}] {run_dir} ({len(frames)} frames)")
+        for frame_id in frames:
+            cloud = reconstruct_point_cloud(run_dir, frame_id, intrinsics, args.z_near, args.z_far,
+                                             args.depth_scale, args.num_points, in_channels)
+            eval_clouds.append(cloud)
+            eval_run_idx.append(run_i)
+    eval_clouds = np.stack(eval_clouds).astype(np.float32)
+    eval_run_idx = np.array(eval_run_idx)
+    print(f"  eval_clouds: {eval_clouds.shape}")
+
+    print("Embedding point clouds with the trained PointNet encoder ...")
+    train_emb = embed_point_clouds(extractor, train_clouds, device)
+    eval_emb = embed_point_clouds(extractor, eval_clouds, device)
+    print(f"  train_emb: {train_emb.shape}, eval_emb: {eval_emb.shape}")
+
+    scaler, pca = fit_pca(train_emb)
+    train_scaled = pca.transform(scaler.transform(train_emb))
+    eval_scaled = pca.transform(scaler.transform(eval_emb))
+    var_explained = pca.explained_variance_ratio_.sum() * 100
+
+    plot_path = args.output_dir / "pca_pointcloud_embedding.png"
+    plot_pca(train_scaled, eval_scaled,
+             f"Point cloud encoder embeddings: train density vs eval rollouts ({var_explained:.1f}% var explained)",
+             plot_path, eval_color=eval_run_idx, eval_cmap_label='eval run index')
+    print(f"Saved {plot_path}")
+
+    train_dist, eval_dist = mahalanobis_scores(train_emb, eval_emb)
+    p95 = np.percentile(train_dist, 95)
+
+    summary_lines = [
+        "=" * 70, "iDP3 Point-Cloud Encoder OOD Check", "=" * 70,
+        f"Checkpoint: {args.ckpt}",
+        f"Training point clouds: {args.zarr_path} ({len(train_clouds)} sampled of {n_train_total})",
+        f"Eval rollouts: {len(runs)} runs, {len(eval_clouds)} frames total",
+        "",
+        mahalanobis_report(train_emb, eval_emb, "point cloud embedding"),
+        "",
+        "-- Per-run breakdown (frames beyond training p95) --",
+    ]
+    for run_i, (run_dir, frames) in enumerate(runs):
+        mask = eval_run_idx == run_i
+        frac = (eval_dist[mask] > p95).mean() * 100
+        summary_lines.append(f"  [{run_i}] {run_dir}: {mask.sum():3d} frames, {frac:5.1f}% beyond training p95")
+
+    summary = "\n".join(summary_lines)
+    print("\n" + summary)
+    (args.output_dir / "summary.txt").write_text(summary + "\n")
+    print(f"\nSaved summary to {args.output_dir / 'summary.txt'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/convert_unitree_to_zarr.py
+++ b/scripts/convert_unitree_to_zarr.py
@@ -16,6 +16,7 @@ Output zarr structure (ReplayBuffer format):
       state        float32 (T, state_dim)   -- concatenated arm + hand qpos
       action       float32 (T, state_dim)   -- same layout as state
       point_cloud  float32 (T, N, 6)        -- XYZ + normalised RGB
+      img          uint8   (T, H, W, 3)     -- RGB image (native resolution)
     meta/
       episode_ends int64   (num_episodes,)
 """
@@ -123,7 +124,7 @@ def process_episode(
     if not frames:
         return None
 
-    ep_states, ep_actions, ep_clouds = [], [], []
+    ep_states, ep_actions, ep_clouds, ep_imgs = [], [], [], []
 
     for frame in frames:
         # --- proprioception ---
@@ -165,11 +166,13 @@ def process_episode(
         ep_states.append(state)
         ep_actions.append(action)
         ep_clouds.append(cloud)
+        ep_imgs.append(rgb)
 
     return (
         np.stack(ep_states),   # (T, state_dim)
         np.stack(ep_actions),  # (T, state_dim)
         np.stack(ep_clouds),   # (T, num_points, 6)
+        np.stack(ep_imgs),     # (T, H, W, 3)
     )
 
 
@@ -221,13 +224,14 @@ def main():
             n_skip += 1
             continue
 
-        ep_states, ep_actions, ep_clouds = result
+        ep_states, ep_actions, ep_clouds, ep_imgs = result
         rb.add_episode({
             "state":       ep_states,
             "action":      ep_actions,
             "point_cloud": ep_clouds,
+            "img":         ep_imgs,
         })
-        print(f"OK  ({len(ep_states)} frames, state_dim={ep_states.shape[1]})")
+        print(f"OK  ({len(ep_states)} frames, state_dim={ep_states.shape[1]}, img={ep_imgs.shape[1:]})")
         n_ok += 1
 
     if n_ok == 0:
@@ -238,9 +242,10 @@ def main():
     rb.save_to_path(str(output_path))
 
     print(f"\nSaved {n_ok} episodes ({n_skip} skipped) → {output_path}")
-    print(f"  state:       {rb['state'].shape}")
-    print(f"  action:      {rb['action'].shape}")
-    print(f"  point_cloud: {rb['point_cloud'].shape}")
+    print(f"  state:        {rb['state'].shape}")
+    print(f"  action:       {rb['action'].shape}")
+    print(f"  point_cloud:  {rb['point_cloud'].shape}")
+    print(f"  img:          {rb['img'].shape}")
     print(f"  episode_ends: {rb.episode_ends[:10]}{'...' if rb.n_episodes > 10 else ''}")
 
 

--- a/scripts/convert_unitree_to_zarr.py
+++ b/scripts/convert_unitree_to_zarr.py
@@ -1,0 +1,248 @@
+"""
+Convert xr_teleoperate episode directories to an iDP3-compatible zarr dataset.
+
+Episode directory structure (xr_teleoperate output):
+  <input_dir>/
+    episode_0000/
+      data.json
+      colors/000000_color_0.jpg  ...
+      depths/000000_depth_0.png  ...
+    episode_0001/
+      ...
+
+Output zarr structure (ReplayBuffer format):
+  <output_zarr>/
+    data/
+      state        float32 (T, state_dim)   -- concatenated arm + hand qpos
+      action       float32 (T, state_dim)   -- same layout as state
+      point_cloud  float32 (T, N, 6)        -- XYZ + normalised RGB
+    meta/
+      episode_ends int64   (num_episodes,)
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+# Allow running from the repo root without installing the package.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "Improved-3D-Diffusion-Policy"))
+
+from diffusion_policy_3d.common.replay_buffer import ReplayBuffer
+
+
+# ---------------------------------------------------------------------------
+# Depth → coloured point cloud
+# ---------------------------------------------------------------------------
+
+def depth_to_colored_pointcloud(
+    depth_m: np.ndarray,        # (H, W) float32, metres
+    rgb: np.ndarray,             # (H, W, 3) uint8
+    fx: float, fy: float, cx: float, cy: float,
+    z_near: float, z_far: float,
+    num_points: int,
+) -> np.ndarray:
+    """Return (num_points, 6) float32 array: [x, y, z, r, g, b]."""
+    H, W = depth_m.shape
+
+    us, vs = np.meshgrid(np.arange(W), np.arange(H))
+    z = depth_m.reshape(-1)
+    x = (us.reshape(-1) - cx) * z / fx
+    y = (vs.reshape(-1) - cy) * z / fy
+
+    mask = (z >= z_near) & (z <= z_far)
+    xyz = np.stack([x, y, z], axis=1)[mask]          # (N_valid, 3)
+    color = (rgb.reshape(-1, 3).astype(np.float32) / 255.0)[mask]  # (N_valid, 3)
+
+    cloud = np.concatenate([xyz, color], axis=1)     # (N_valid, 6)
+
+    n = len(cloud)
+    if n == 0:
+        return np.zeros((num_points, 6), dtype=np.float32)
+
+    if n >= num_points:
+        idx = np.random.choice(n, num_points, replace=False)
+    else:
+        idx = np.concatenate([
+            np.arange(n),
+            np.random.choice(n, num_points - n, replace=True),
+        ])
+    return cloud[idx].astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# JSON state / action helpers
+# ---------------------------------------------------------------------------
+
+def _get_nested(d: dict, dotted_key: str) -> list:
+    """Walk 'left_arm.qpos' style keys."""
+    keys = dotted_key.split(".")
+    v = d
+    for k in keys:
+        v = v[k]
+    return v
+
+
+STATE_KEYS = ["left_arm.qpos", "right_arm.qpos", "left_ee.qpos", "right_ee.qpos"]
+
+
+def extract_vector(frame_dict: dict, section: str) -> np.ndarray:
+    """Concatenate all joint-position fields from states or actions."""
+    parts = []
+    for k in STATE_KEYS:
+        top, field = k.split(".", 1)
+        val = frame_dict[section][top][field]
+        if val:
+            parts.append(np.array(val, dtype=np.float32))
+    return np.concatenate(parts) if parts else np.array([], dtype=np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Episode processing
+# ---------------------------------------------------------------------------
+
+def process_episode(
+    episode_dir: Path,
+    fx: float, fy: float, cx: float, cy: float,
+    color_key: str, depth_key: str,
+    depth_scale: float,
+    z_near: float, z_far: float,
+    num_points: int,
+):
+    data_json = episode_dir / "data.json"
+    if not data_json.exists():
+        return None
+
+    with open(data_json) as f:
+        data = json.load(f)
+
+    frames = data.get("data", [])
+    if not frames:
+        return None
+
+    ep_states, ep_actions, ep_clouds = [], [], []
+
+    for frame in frames:
+        # --- proprioception ---
+        state  = extract_vector(frame, "states")
+        action = extract_vector(frame, "actions")
+
+        # --- point cloud from depth + colour ---
+        depth_rel = frame.get("depths", {}).get(depth_key)
+        color_rel = frame.get("colors", {}).get(color_key)
+
+        if depth_rel is None or color_rel is None:
+            print(f"  [warn] frame {frame['idx']} missing {depth_key}/{color_key}, skipping episode")
+            return None
+
+        depth_path = episode_dir / depth_rel
+        color_path = episode_dir / color_rel
+
+        depth_raw = cv2.imread(str(depth_path), cv2.IMREAD_ANYDEPTH)
+        if depth_raw is None:
+            print(f"  [warn] could not read {depth_path}, skipping episode")
+            return None
+        depth_m = depth_raw.astype(np.float32) / depth_scale
+
+        bgr = cv2.imread(str(color_path))
+        if bgr is None:
+            print(f"  [warn] could not read {color_path}, skipping episode")
+            return None
+        rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+
+        # align resolutions
+        if depth_m.shape[:2] != rgb.shape[:2]:
+            h, w = rgb.shape[:2]
+            depth_m = cv2.resize(depth_m, (w, h), interpolation=cv2.INTER_NEAREST)
+
+        cloud = depth_to_colored_pointcloud(
+            depth_m, rgb, fx, fy, cx, cy, z_near, z_far, num_points
+        )
+
+        ep_states.append(state)
+        ep_actions.append(action)
+        ep_clouds.append(cloud)
+
+    return (
+        np.stack(ep_states),   # (T, state_dim)
+        np.stack(ep_actions),  # (T, state_dim)
+        np.stack(ep_clouds),   # (T, num_points, 6)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert xr_teleoperate episodes to iDP3 zarr")
+    parser.add_argument("--input_dir",   required=True,  help="Folder containing episode_XXXX/ subdirs")
+    parser.add_argument("--output_zarr", required=True,  help="Output zarr path")
+    parser.add_argument("--fx",   type=float, required=True, help="Camera focal length x (pixels)")
+    parser.add_argument("--fy",   type=float, required=True, help="Camera focal length y (pixels)")
+    parser.add_argument("--cx",   type=float, required=True, help="Camera principal point x (pixels)")
+    parser.add_argument("--cy",   type=float, required=True, help="Camera principal point y (pixels)")
+    parser.add_argument("--color_key",   default="color_0", help="Color image key in data.json (default: color_0)")
+    parser.add_argument("--depth_key",   default="depth_0", help="Depth image key in data.json (default: depth_0)")
+    parser.add_argument("--depth_scale", type=float, default=1000.0, help="Divide raw depth by this to get metres (default: 1000.0)")
+    parser.add_argument("--z_near",      type=float, default=0.1,    help="Minimum depth in metres (default: 0.1)")
+    parser.add_argument("--z_far",       type=float, default=1.5,    help="Maximum depth in metres (default: 1.5)")
+    parser.add_argument("--num_points",  type=int,   default=4096,   help="Points per cloud (default: 4096)")
+    parser.add_argument("--seed",        type=int,   default=42)
+    args = parser.parse_args()
+
+    np.random.seed(args.seed)
+
+    input_dir = Path(args.input_dir)
+    episode_dirs = sorted(d for d in input_dir.iterdir() if d.is_dir() and d.name.startswith("episode"))
+
+    if not episode_dirs:
+        sys.exit(f"No episode_XXXX/ directories found in {input_dir}")
+
+    print(f"Found {len(episode_dirs)} episode directories")
+
+    rb = ReplayBuffer.create_empty_numpy()
+    n_ok, n_skip = 0, 0
+
+    for ep_dir in episode_dirs:
+        print(f"  Processing {ep_dir.name} ...", end=" ", flush=True)
+        result = process_episode(
+            ep_dir,
+            args.fx, args.fy, args.cx, args.cy,
+            args.color_key, args.depth_key,
+            args.depth_scale, args.z_near, args.z_far,
+            args.num_points,
+        )
+        if result is None:
+            print("SKIPPED")
+            n_skip += 1
+            continue
+
+        ep_states, ep_actions, ep_clouds = result
+        rb.add_episode({
+            "state":       ep_states,
+            "action":      ep_actions,
+            "point_cloud": ep_clouds,
+        })
+        print(f"OK  ({len(ep_states)} frames, state_dim={ep_states.shape[1]})")
+        n_ok += 1
+
+    if n_ok == 0:
+        sys.exit("No episodes were converted successfully.")
+
+    output_path = Path(args.output_zarr)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    rb.save_to_path(str(output_path))
+
+    print(f"\nSaved {n_ok} episodes ({n_skip} skipped) → {output_path}")
+    print(f"  state:       {rb['state'].shape}")
+    print(f"  action:      {rb['action'].shape}")
+    print(f"  point_cloud: {rb['point_cloud'].shape}")
+    print(f"  episode_ends: {rb.episode_ends[:10]}{'...' if rb.n_episodes > 10 else ''}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ood_common.py
+++ b/scripts/ood_common.py
@@ -1,0 +1,69 @@
+"""Shared helpers for PCA / Mahalanobis OOD analysis scripts (analyze_ood*.py)."""
+
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from sklearn.decomposition import PCA
+from sklearn.preprocessing import StandardScaler
+
+
+def fit_pca(train_data, n_components=2):
+    scaler = StandardScaler().fit(train_data)
+    pca = PCA(n_components=n_components).fit(scaler.transform(train_data))
+    return scaler, pca
+
+
+def mahalanobis_scores(train_data, eval_data):
+    """Mahalanobis distance of each row to the training distribution."""
+    mean = train_data.mean(axis=0)
+    cov = np.cov(train_data, rowvar=False)
+    inv_cov = np.linalg.pinv(cov)
+
+    def dist(x):
+        diff = x - mean
+        return np.sqrt(np.einsum('ij,jk,ik->i', diff, inv_cov, diff))
+
+    return dist(train_data), dist(eval_data)
+
+
+def mahalanobis_report(train_data, eval_data, name):
+    train_dist, eval_dist = mahalanobis_scores(train_data, eval_data)
+    p95, p99 = np.percentile(train_dist, [95, 99])
+    frac_95 = (eval_dist > p95).mean() * 100
+    frac_99 = (eval_dist > p99).mean() * 100
+    lines = [
+        f"-- {name}: Mahalanobis distance to training distribution --",
+        f"  training self-distance: mean={train_dist.mean():.3f}, p95={p95:.3f}, "
+        f"p99={p99:.3f}, max={train_dist.max():.3f}",
+        f"  eval distance:          mean={eval_dist.mean():.3f}, "
+        f"p95={np.percentile(eval_dist, 95):.3f}, max={eval_dist.max():.3f}",
+        f"  eval samples beyond training p95: {frac_95:.1f}%",
+        f"  eval samples beyond training p99: {frac_99:.1f}%",
+    ]
+    return "\n".join(lines)
+
+
+def plot_pca(train_scaled, eval_scaled, title, out_path, eval_color=None,
+              eval_cmap_label='eval timestep', connect_line=False):
+    fig, ax = plt.subplots(figsize=(7, 6))
+    hb = ax.hexbin(train_scaled[:, 0], train_scaled[:, 1], gridsize=40, cmap='Greys', mincnt=1)
+    fig.colorbar(hb, ax=ax, label='training point density')
+
+    if eval_color is None:
+        eval_color = np.arange(len(eval_scaled))
+
+    if connect_line:
+        ax.plot(eval_scaled[:, 0], eval_scaled[:, 1], color='red', alpha=0.3, linewidth=1, zorder=1)
+
+    sc = ax.scatter(eval_scaled[:, 0], eval_scaled[:, 1], c=eval_color,
+                     cmap='plasma', s=12, alpha=0.8, label='eval rollout', zorder=2)
+    fig.colorbar(sc, ax=ax, label=eval_cmap_label)
+
+    ax.set_xlabel('PC1')
+    ax.set_ylabel('PC2')
+    ax.set_title(title)
+    ax.legend(loc='best')
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=120)
+    plt.close(fig)

--- a/scripts/train_g1_slurm.sh
+++ b/scripts/train_g1_slurm.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#SBATCH --job-name=idp3_g1_bucket              # Job name
+#SBATCH --account=es_coros                     # Account name (don't change)
+#SBATCH --gpus=rtx_4090:1                      # 1x RTX 4090
+#SBATCH --ntasks=1                             # Single-node training
+#SBATCH --cpus-per-task=16                     # DataLoader workers (8) + headroom
+#SBATCH --mem-per-cpu=4G                       # 16 x 4G = 64G total
+#SBATCH --time=24:00:00                        # adjust down if it finishes sooner
+#SBATCH --output=idp3_g1_train_%j.log          # Log file with job ID
+
+echo "$(date) start ${SLURM_JOB_ID}"
+
+# ── Modules ────────────────────────────────────────────────────────────────────
+module purge
+module load stack/2025-06 gcc/8.5.0
+
+# ── Conda environment ──────────────────────────────────────────────────────────
+# Source conda init so `conda activate` works inside the job shell.
+# Adjust the path below if your conda lives somewhere other than ~/anaconda3
+# (e.g. ~/miniconda3).
+source "$HOME/anaconda3/etc/profile.d/conda.sh"
+conda activate idp3
+
+# ── Working directory ──────────────────────────────────────────────────────────
+# Submit this job from the repo root (Improved-3D-Diffusion-Policy), e.g.:
+#   sbatch scripts/train_g1_slurm.sh [addition_info]
+cd "$SLURM_SUBMIT_DIR"
+
+# ── Training ───────────────────────────────────────────────────────────────────
+# Single-GPU run; train_policy.sh already pins CUDA_VISIBLE_DEVICES=0 and
+# launches a plain `python train.py` (no accelerate/multi-GPU needed).
+echo "Launching iDP3 training on $(nvidia-smi --query-gpu=name --format=csv,noheader | tr '\n' ' ')"
+
+addition_info=${1:-empty_bucket_v2_rgb_aug}
+
+bash scripts/train_policy.sh idp3 g1_dex-3d "${addition_info}"
+
+echo "$(date) done ${SLURM_JOB_ID}"
+seff "${SLURM_JOB_ID}"

--- a/scripts/train_policy.sh
+++ b/scripts/train_policy.sh
@@ -4,10 +4,10 @@
 #   bash scripts/train_policy.sh dp_224x224_r3m gr1_dex-image 0913_example
 #   bash scripts/train_policy.sh idp3 g1_dex-3d empty_bucket_v2
 
-dataset_path=/home/luke/MSMD/repos/Improved-3D-Diffusion-Policy/Improved-3D-Diffusion-Policy/data/g1_empty_bucket_v2
+dataset_path=~/MSMD/repos/Improved-3D-Diffusion-Policy/Improved-3D-Diffusion-Policy/data/g1_empty_bucket_v2
 
 
-DEBUG=True
+DEBUG=False
 wandb_mode=offline
 
 
@@ -51,7 +51,10 @@ python train.py --config-name=${config_name}.yaml \
                             checkpoint.save_ckpt=${save_ckpt} \
                             task.dataset.zarr_path=$dataset_path \
                             dataloader.batch_size=24 \
-                            val_dataloader.batch_size=24
+                            val_dataloader.batch_size=24 \
+                            policy.use_pc_color=true \
+                            policy.pointcloud_encoder_cfg.in_channels=6 \
+                            training.resume=false
 
 
 

--- a/scripts/train_policy.sh
+++ b/scripts/train_policy.sh
@@ -2,11 +2,12 @@
 
 #   bash scripts/train_policy.sh idp3 gr1_dex-3d 0913_example
 #   bash scripts/train_policy.sh dp_224x224_r3m gr1_dex-image 0913_example
+#   bash scripts/train_policy.sh idp3 g1_dex-3d empty_bucket_v2
 
-dataset_path=/home/ze/projects/Improved-3D-Diffusion-Policy/training_data_example
+dataset_path=/home/luke/MSMD/repos/Improved-3D-Diffusion-Policy/Improved-3D-Diffusion-Policy/data/g1_empty_bucket_v2
 
 
-DEBUG=False
+DEBUG=True
 wandb_mode=offline
 
 
@@ -48,7 +49,9 @@ python train.py --config-name=${config_name}.yaml \
                             exp_name=${exp_name} \
                             logging.mode=${wandb_mode} \
                             checkpoint.save_ckpt=${save_ckpt} \
-                            task.dataset.zarr_path=$dataset_path 
+                            task.dataset.zarr_path=$dataset_path \
+                            dataloader.batch_size=24 \
+                            val_dataloader.batch_size=24
 
 
 

--- a/scripts/vis_dataset.sh
+++ b/scripts/vis_dataset.sh
@@ -1,11 +1,11 @@
 # bash scripts/vis_dataset.sh
 
-dataset_path=/home/ze/projects/Improved-3D-Diffusion-Policy/training_data_example
+dataset_path=/home/luke/MSMD/repos/Improved-3D-Diffusion-Policy/Improved-3D-Diffusion-Policy/data/g1_empty_bucket_v2
 
-vis_cloud=0
+vis_cloud=1
 cd Improved-3D-Diffusion-Policy
 python vis_dataset.py --dataset_path $dataset_path \
                     --use_img 1 \
                     --vis_cloud ${vis_cloud} \
                     --use_pc_color 0 \
-                    --downsample 1 \
+                    --downsample 0 \


### PR DESCRIPTION
- scripts/convert_unitree_to_zarr.py: converts xr_teleoperate JSON
  episodes (depth PNGs + colour JPEGs + data.json) into a ReplayBuffer
  zarr dataset consumable by GR1DexDataset3D
- diffusion_policy_3d/common/g1_action_util.py: G1 joint layout constants
  and split/join helpers (no remapping needed unlike GR1)
- diffusion_policy_3d/config/task/g1_dex-3d.yaml: Hydra task config for
  G1 (agent_pos/action dim 26 instead of GR1's 32/25)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>